### PR TITLE
Add --no-color option and --format line for issue #5

### DIFF
--- a/src/formatter.lisp
+++ b/src/formatter.lisp
@@ -7,7 +7,9 @@
            #:format-line-file
            #:format-text-summary
            #:format-json-start
-           #:format-json-end))
+           #:format-json-end
+           #:*no-color*
+           #:use-colors-p))
 (in-package #:mallet/formatter)
 
 ;;; ANSI color codes
@@ -17,6 +19,9 @@
 (defparameter *color-yellow* (format nil "~C[33m" #\Escape))
 (defparameter *color-gray* (format nil "~C[90m" #\Escape))
 (defparameter *color-green* (format nil "~C[32m" #\Escape))
+
+(defvar *no-color* nil
+  "When T, disable all ANSI color output regardless of terminal type.")
 
 ;;; Path utilities
 
@@ -42,8 +47,9 @@ If FILE cannot be made relative, returns the namestring as-is."
         (namestring file-path))))
 
 (defun use-colors-p (stream)
-  "Check if we should use colors for STREAM (only if it's a TTY)."
-  (and (member stream (list *standard-output* *error-output*))
+  "Check if we should use colors for STREAM (only if it's a TTY and *no-color* is nil)."
+  (and (not *no-color*)
+       (member stream (list *standard-output* *error-output*))
        (interactive-stream-p stream)))
 
 (defun colorize (text color stream)

--- a/src/main.lisp
+++ b/src/main.lisp
@@ -201,12 +201,13 @@ Returns (rule-name . options-plist)."
 
 (defun parse-args (args)
   "Parse command-line ARGS into options and files.
-Returns (values format config-path preset debug fix-mode cli-rules files).
+Returns (values format config-path preset debug no-color fix-mode cli-rules files).
 Signals specific error conditions for invalid input."
   (let ((format :text)
         (config-path nil)
         (preset nil)
         (debug nil)
+        (no-color nil)
         (fix-mode nil)
         (enable-rules '())
         (disable-rules '())
@@ -231,6 +232,8 @@ Signals specific error conditions for invalid input."
            (setf preset :none))
           ((string= arg "--debug")
            (setf debug t))
+          ((string= arg "--no-color")
+           (setf no-color t))
           ((string= arg "--fix")
            (setf fix-mode :fix))
           ((string= arg "--fix-dry-run")
@@ -269,7 +272,7 @@ Signals specific error conditions for invalid input."
                            :disable-rules (nreverse disable-rules)
                            :enable-groups (nreverse enable-groups)
                            :disable-groups (nreverse disable-groups))))
-      (values format config-path preset debug fix-mode cli-rules (nreverse files)))))
+      (values format config-path preset debug no-color fix-mode cli-rules (nreverse files)))))
 
 
 (defun print-help ()
@@ -294,6 +297,7 @@ Options:
 
   --fix               Auto-fix violations and write files
   --fix-dry-run       Show what would be fixed without writing files
+  --no-color          Disable ANSI color codes in output
   --debug             Enable debug mode with detailed diagnostics
   --help              Show this help message
   --version           Show version information
@@ -460,11 +464,15 @@ Lints files specified in ARGS and exits with appropriate status code."
                    (uiop:print-condition-backtrace e))
                  (uiop:quit 3))))
 
-          (multiple-value-bind (format config-path preset debug fix-mode cli-rules file-args)
+          (multiple-value-bind (format config-path preset debug no-color fix-mode cli-rules file-args)
               (parse-args args)
 
             ;; Enable debug mode if requested
             (setf *debug-mode* debug)
+
+            ;; Disable colors if requested
+            (when no-color
+              (setf formatter:*no-color* t))
 
             ;; Validate we have files to lint
             (when (null file-args)

--- a/tests/formatter-test.lisp
+++ b/tests/formatter-test.lisp
@@ -99,6 +99,14 @@
       (ok (search "[FIXED]" output))
       (ok (not (search "format:" output))))))
 
+(deftest no-color-test
+  (testing "use-colors-p returns nil when *no-color* is true"
+    (let ((formatter:*no-color* t))
+      (ok (null (formatter:use-colors-p *standard-output*)))))
+
+  (testing "*no-color* defaults to nil"
+    (ok (null formatter:*no-color*))))
+
 (deftest format-text-file-test
   (testing "format-text-file groups violations by file"
     (let* ((file (pathname "/path/to/file.lisp"))


### PR DESCRIPTION
- Add `--no-color` flag to disable ANSI color codes in output
- Export `*no-color*` special variable from `mallet/formatter` for programmatic use (e.g., piping to other tools or CI environments)
- Export `use-colors-p` helper function
- Note: `--format line` already provides per-line file prefixes (GCC/GNU format: file:line:col: severity: message [rule])

Closes #5