### PR TITLE
Exclude .claude directory from linting by default

### DIFF
--- a/src/main.lisp
+++ b/src/main.lisp
@@ -338,7 +338,7 @@ Examples:
   "Expand FILE-ARGS into a list of Lisp file pathnames.
 Handles wildcards and directories, excluding common non-source directories."
   (let ((files '())
-        (excluded-dirs '(".qlot" ".bundle-libs" ".git" ".svn" ".hg" "node_modules" "_build")))
+        (excluded-dirs '(".qlot" ".bundle-libs" ".git" ".svn" ".hg" "node_modules" "_build" ".claude")))
     (labels ((should-exclude-p (path)
                "Check if PATH is in an excluded directory."
                (let ((path-string (namestring path)))


### PR DESCRIPTION
## Summary

- Add `.claude` to the default excluded directories in `expand-file-args`

## Motivation

The `.claude` directory may contain git worktrees, which would otherwise be picked up during recursive file expansion and linted unintentionally.