### PR TITLE
Handle single escape and string escapes in tokenizer

### DIFF
--- a/src/parser/tokenizer.lisp
+++ b/src/parser/tokenizer.lisp
@@ -43,6 +43,18 @@ Matches:
   (and (not (whitespace-char-p char))
        (not (member char '(#\( #\) #\; #\" #\' #\` #\,)))))
 
+(defun scan-constituent (text pos len)
+  "Advance POS past a constituent token in TEXT, handling single escapes.
+Returns the new position."
+  (loop while (and (< pos len)
+                   (constituent-char-p (char text pos)))
+        do (cond
+             ((char= (char text pos) #\\)
+              (incf pos)
+              (when (< pos len) (incf pos)))
+             (t (incf pos))))
+  pos)
+
 (defun tokenize (text file)
   "Tokenize TEXT from FILE, preserving comments and positions.
 Returns a list of TOKEN objects."
@@ -114,7 +126,11 @@ Returns a list of TOKEN objects."
           ((char= ch #\")
            (let* ((start-pos pos)
                   (start-column column)
-                  (end-pos (position #\" text :start (1+ pos)))
+                  (end-pos (loop for i from (1+ pos) below len
+                                do (let ((c (char text i)))
+                                     (cond
+                                       ((char= c #\\) (incf i))
+                                       ((char= c #\") (return i))))))
                   (raw
                     (if end-pos
                         (subseq text start-pos (1+ end-pos))
@@ -126,11 +142,9 @@ Returns a list of TOKEN objects."
 
           ;; Symbols and numbers
           ((constituent-char-p ch)
-           (let* ((start-pos pos)
-                  (start-column column))
-             (loop while (and (< pos len)
-                              (constituent-char-p (char text pos)))
-                   do (incf pos))
+           (let ((start-pos pos)
+                 (start-column column))
+             (setf pos (scan-constituent text pos len))
              (let* ((raw (subseq text start-pos pos))
                     (type (if (ppcre:scan *number-pattern* raw)
                               :number

--- a/tests/parser/tokenizer-test.lisp
+++ b/tests/parser/tokenizer-test.lisp
@@ -62,3 +62,35 @@
     (let* ((text ";;; Section\n(defun foo ())")
            (tokens (parser:tokenize text #P"test.lisp")))
       (ok (find :comment-section tokens :key #'parser:token-type)))))
+
+(deftest tokenize-single-escape
+  (testing "Character literal #\\\" is a single token"
+    (let* ((text "(char= ch #\\\")")
+           (tokens (parser:tokenize text #P"test.lisp"))
+           (types (mapcar #'parser:token-type tokens)))
+      (ok (equal types '(:open-paren :symbol :symbol :symbol :close-paren)))
+      (ok (string= "#\\\"" (parser:token-raw (fourth tokens))))))
+
+  (testing "Character literal #\\( is a single token"
+    (let* ((text "(char= ch #\\()")
+           (tokens (parser:tokenize text #P"test.lisp"))
+           (types (mapcar #'parser:token-type tokens)))
+      (ok (equal types '(:open-paren :symbol :symbol :symbol :close-paren)))
+      (ok (string= "#\\(" (parser:token-raw (fourth tokens)))))))
+
+(deftest tokenize-escaped-quotes-in-strings
+  (testing "Escaped quote within string"
+    (let* ((text "(format nil \"hello \\\"world\\\"\")")
+           (tokens (parser:tokenize text #P"test.lisp"))
+           (string-tokens (remove-if-not (lambda (tok)
+                                           (eq (parser:token-type tok) :string))
+                                         tokens)))
+      (ok (= 1 (length string-tokens)))))
+
+  (testing "Escaped backslash before closing quote"
+    (let* ((text "(print \"ends with backslash\\\\\")")
+           (tokens (parser:tokenize text #P"test.lisp"))
+           (string-tokens (remove-if-not (lambda (tok)
+                                           (eq (parser:token-type tok) :string))
+                                         tokens)))
+      (ok (= 1 (length string-tokens))))))

--- a/tests/rules/bare-float-literal-test.lisp
+++ b/tests/rules/bare-float-literal-test.lisp
@@ -131,3 +131,13 @@
 
   (testing "Float in comment - no violation"
     (ok (null (check-bare-floats "; 1.0")))))
+
+(deftest character-literals-not-flagged
+  (testing "Character literal for double-quote does not cause false positive"
+    (ok (null (check-bare-floats "(char= ch #\\\")"))))
+
+  (testing "Character literal for open-paren"
+    (ok (null (check-bare-floats "(char= ch #\\()"))))
+
+  (testing "Regular character literals are fine"
+    (ok (null (check-bare-floats "(char= ch #\\a)")))))


### PR DESCRIPTION
## Summary

- Fix tokenizer not handling CL single escape character (`\`) in constituent tokens — `#\"` was split into `#\` + a string starting at `"`, causing `bare-float-literal` and other rules to fire on misinterpreted tokens
- Fix tokenizer not handling escaped quotes (`\"`) inside string literals — `"...\"~A\"..."` format strings were terminated at the first `\"`, swallowing subsequent code
- Extract `scan-constituent` helper to keep `tokenize` cyclomatic complexity within bounds

## Test plan

- [x] New tokenizer tests for `#\"`, `#\(` character literals
- [x] New tokenizer tests for escaped quotes and escaped backslashes in strings
- [x] New bare-float-literal tests for character literal false positives
- [x] All existing tokenizer and bare-float-literal tests pass
- [x] Pre-commit lint hook passes