### PR TITLE
Fix false positives in asdf-component-strings for :perform bodies

### DIFF
--- a/src/rules/forms/asdf.lisp
+++ b/src/rules/forms/asdf.lisp
@@ -32,39 +32,58 @@
 
 ;;; Helper functions
 
-(defun looks-like-symbol-p (str &optional source)
-  "Check if STR looks like it was parsed from a symbol (not a string literal).
-The parser converts symbols to strings, so we check for patterns like:
-  - ':ALEXANDRIA' (keyword)
-  - 'CURRENT:FOO' (package-qualified symbol)
-For plain strings like 'main', check SOURCE for '#:' pattern if provided.
-Returns NIL for non-string inputs (like Eclector objects)."
-  (and (stringp str)
+(defun source-offset (source form-line form-column target-line target-column)
+  "Convert absolute (TARGET-LINE, TARGET-COLUMN) to a character offset in SOURCE.
+SOURCE starts at (FORM-LINE, FORM-COLUMN). Returns offset or NIL if out of range."
+  (let ((offset 0)
+        (current-line form-line))
+    (loop while (< current-line target-line)
+          do (let ((nl (position #\Newline source :start offset)))
+               (unless nl
+                 (return-from source-offset nil))
+               (setf offset (1+ nl))
+               (incf current-line)))
+    (let ((result (if (= target-line form-line)
+                      (+ offset (- target-column form-column))
+                      (+ offset target-column))))
+      (when (and (>= result 0) (< result (length source)))
+        result))))
+
+(defun source-char-at (value form)
+  "Return the character at VALUE's position in the form source, or NIL.
+Uses the position-map to find where VALUE appears in the raw source text."
+  (let ((position-map (parser:form-position-map form))
+        (source (parser:form-source form)))
+    (when (and position-map source)
+      (let ((pos (gethash value position-map)))
+        (when pos
+          (let ((offset (source-offset source
+                                       (parser:form-line form)
+                                       (parser:form-column form)
+                                       (car pos) (cdr pos))))
+            (when offset
+              (char source offset))))))))
+
+(defun value-is-symbol-p (value form)
+  "Check if VALUE (a string from the parsed expr) was written as a symbol in source.
+Uses the position-map for precise, scoped detection."
+  (and (stringp value)
        (or
-        ;; Keyword: starts with ":"
-        (utils:keyword-string-p str)
-        ;; Package-qualified: has ":" but not at start (e.g., "CURRENT:FOO")
-        (and (find #\: str :test #'char=)  ; Be explicit about test function
-             (not (utils:keyword-string-p str)))
-        ;; Plain string - check source for #: pattern if available
-        (and source
-             (stringp source)
-             (let* ((name (extract-symbol-name str))
-                    (pattern (format nil "#:~A" name)))
-               (search pattern source :test #'char-equal))))))
+        (utils:keyword-string-p value)
+        (and (find #\: value :test #'char=)
+             (not (utils:keyword-string-p value)))
+        (let ((ch (source-char-at value form)))
+          (and ch (not (char= ch #\")))))))
 
 (defun extract-symbol-name (str)
   "Extract the base name from a symbol string for display.
 Examples: ':ALEXANDRIA' -> 'alexandria', 'CURRENT:FOO' -> 'foo'
 Handles non-string inputs (like Eclector objects) gracefully by returning a default value."
   (if (not (stringp str))
-      ;; Not a string - try to get a reasonable representation
       (if (and (consp str) (symbolp (first str)))
-          (format nil "~A" (first str))  ; Best effort for Eclector objects
-          (format nil "~A" str))          ; Last resort - princ it
-      ;; Normal string processing
+          (format nil "~A" (first str))
+          (format nil "~A" str))
       (cond
-        ;; Keyword: ":ALEXANDRIA" -> "alexandria"
         ((utils:keyword-string-p str)
          (string-downcase (subseq str 1)))
         ;; Uninterned: "#:FOO" -> "foo"
@@ -73,142 +92,95 @@ Handles non-string inputs (like Eclector objects) gracefully by returning a defa
         ;; Package-qualified: "CURRENT:FOO" -> "foo"
         ((find #\: str :test #'char=)
          (string-downcase (subseq str (1+ (position #\: str :from-end t :test #'char=)))))
-        ;; Plain: "FOO" -> "foo"
         (t (string-downcase str)))))
 
-(defun format-symbol-for-message (str source)
-  "Format STR as it appeared in SOURCE for error messages.
-Examples: 'my-system' with '#:my-system' in source -> '#:my-system'
-          ':alexandria' -> ':alexandria'
-          'CURRENT:foo' -> 'foo'"
-  (let ((name (extract-symbol-name str)))
+(defun format-symbol-for-message (value form)
+  "Format VALUE as it appeared in source for error messages.
+Uses position-map to determine the original notation."
+  (let ((name (extract-symbol-name value)))
     (cond
-      ;; Check if it's a keyword in the parsed string
-      ((utils:keyword-string-p str)
+      ((utils:keyword-string-p value)
        (format nil ":~A" name))
-      ;; Check source for #: pattern
-      ((and source (stringp source)
-            (search (format nil "#:~A" name) source :test #'char-equal))
-       (format nil "#:~A" name))
-      ;; Plain symbol (including package-qualified ones) - just show the name
-      (t name))))
+      (t
+       (let ((ch (source-char-at value form)))
+         (if (and ch (char= ch #\#))
+             (format nil "#:~A" name)
+             name))))))
 
-(defun find-symbol-in-source (symbol-str source start-offset)
-  "Find SYMBOL-STR in SOURCE starting from START-OFFSET.
-Returns (values line column) relative to start of SOURCE, or (values 0 0) if not found."
-  (let* ((symbol-name (extract-symbol-name symbol-str))
-         ;; Try different patterns the symbol might appear as
-         (patterns (list
-                    (format nil ":~A" symbol-name)  ; :alexandria
-                    (format nil "#:~A" symbol-name) ; #:foo
-                    symbol-name)))                   ; bare symbol
-    (dolist (pattern patterns)
-      (let ((pos (search pattern source :start2 start-offset :test #'char-equal)))
-        (when pos
-          ;; Calculate line and column
-          (let ((line 0)
-                (column 0))
-            (loop for i from 0 below pos
-                  for char = (char source i)
-                  do (cond
-                       ((char= char #\Newline)
-                        (incf line)
-                        (setf column 0))
-                       (t
-                        (incf column))))
-            (return-from find-symbol-in-source (values line column))))))
-    ;; Not found - return 0, 0
-    (values 0 0)))
-
-(defun create-violation (symbol-value form file severity message)
-  "Create a violation for SYMBOL-VALUE, finding its position in source."
-  (let ((source (parser:form-source form))
-        (base-line (parser:form-line form))
-        (base-column (parser:form-column form)))
-    (multiple-value-bind (rel-line rel-column)
-        (if source
-            (find-symbol-in-source symbol-value source 0)
-            (values 0 0))
+(defun create-violation (value form file severity message)
+  "Create a violation for VALUE, using position-map for its location."
+  (let ((position-map (parser:form-position-map form)))
+    (multiple-value-bind (line column)
+        (parser:find-position value position-map
+                              (parser:form-line form)
+                              (parser:form-column form))
       (make-instance 'violation:violation
                      :rule :asdf-component-strings
                      :file file
-                     :line (+ base-line rel-line)
-                     :column (if (zerop rel-line)
-                                 (+ base-column rel-column)
-                                 rel-column)
+                     :line line
+                     :column column
                      :severity severity
                      :message message))))
 
 (defun check-dependency (dep form file severity)
   "Check a single dependency DEP for symbol usage.
 Handles: simple-name | (:feature expr dep) | (:version name ver) | (:require name)"
-  (let ((source (parser:form-source form)))
-    (cond
-      ;; Simple dependency - just a name string
-      ((stringp dep)
-       (when (looks-like-symbol-p dep source)
-         (list (create-violation dep form file severity
-                                 (format nil "Dependency should be string \"~A\", instead of symbol ~A"
-                                         (extract-symbol-name dep)
-                                         (format-symbol-for-message dep source))))))
+  (cond
+    ((stringp dep)
+     (when (value-is-symbol-p dep form)
+       (list (create-violation dep form file severity
+                               (format nil "Dependency should be string \"~A\", instead of symbol ~A"
+                                       (extract-symbol-name dep)
+                                       (format-symbol-for-message dep form))))))
 
-      ;; Complex dependency - list form
-      ((consp dep)
-       (when (>= (length dep) 2)
-         (let ((dep-type (first dep)))
-           (when (stringp dep-type)
-             (let ((type-name (base:symbol-name-from-string dep-type)))
-               (cond
-                 ;; (:version "system" "1.0") - check system name (2nd element)
-                 ((string-equal type-name "VERSION")
-                  (when (>= (length dep) 2)
-                    (let ((sys-name (second dep)))
-                      (when (looks-like-symbol-p sys-name source)
-                        (list (create-violation sys-name form file severity
-                                                (format nil "System name should be string \"~A\", instead of symbol ~A"
-                                                        (extract-symbol-name sys-name)
-                                                        (format-symbol-for-message sys-name source))))))))
+    ((consp dep)
+     (when (>= (length dep) 2)
+       (let ((dep-type (first dep)))
+         (when (stringp dep-type)
+           (let ((type-name (base:symbol-name-from-string dep-type)))
+             (cond
+               ((string-equal type-name "VERSION")
+                (when (>= (length dep) 2)
+                  (let ((sys-name (second dep)))
+                    (when (value-is-symbol-p sys-name form)
+                      (list (create-violation sys-name form file severity
+                                              (format nil "System name should be string \"~A\", instead of symbol ~A"
+                                                      (extract-symbol-name sys-name)
+                                                      (format-symbol-for-message sys-name form))))))))
 
-                 ;; (:require "module") - check module name (2nd element)
-                 ((string-equal type-name "REQUIRE")
-                  (when (>= (length dep) 2)
-                    (let ((mod-name (second dep)))
-                      (when (looks-like-symbol-p mod-name source)
-                        (list (create-violation mod-name form file severity
-                                                (format nil "Module name should be string \"~A\", instead of symbol ~A"
-                                                        (extract-symbol-name mod-name)
-                                                        (format-symbol-for-message mod-name source))))))))
+               ((string-equal type-name "REQUIRE")
+                (when (>= (length dep) 2)
+                  (let ((mod-name (second dep)))
+                    (when (value-is-symbol-p mod-name form)
+                      (list (create-violation mod-name form file severity
+                                              (format nil "Module name should be string \"~A\", instead of symbol ~A"
+                                                      (extract-symbol-name mod-name)
+                                                      (format-symbol-for-message mod-name form))))))))
 
-                 ;; (:feature expr dependency-def) - recursively check dependency-def (3rd element)
-                 ((string-equal type-name "FEATURE")
-                  (when (>= (length dep) 3)
-                    (check-dependency (third dep) form file severity)))
+               ((string-equal type-name "FEATURE")
+                (when (>= (length dep) 3)
+                  (check-dependency (third dep) form file severity)))
 
-                 ;; Unknown list form - don't flag
-                 (t nil)))))))
+               (t nil)))))))
 
-      ;; Unknown form
-      (t nil))))
+    (t nil)))
 
 (defun check-in-order-to-list (in-order-to-clauses form file severity)
   "Check :in-order-to clauses for symbol usage in system names.
 Structure: ((operation (operation system-name) ...) ...)"
-  (let ((violations '())
-        (source (parser:form-source form)))
+  (let ((violations '()))
     (dolist (clause in-order-to-clauses)
       (when (consp clause)
-        ;; Each clause: (operation (operation system-name) ...)
-        ;; Skip first element (operation), check rest (dependencies)
         (dolist (dependency (rest clause))
           (when (and (consp dependency)
                      (>= (length dependency) 2))
             (let ((system-name (second dependency)))
-              (when (looks-like-symbol-p system-name source)
+              (when (value-is-symbol-p system-name form)
                 (let ((sym-name (extract-symbol-name system-name)))
                   (push (create-violation system-name form file severity
                                           (format nil "System name should be string \"~A\", instead of symbol ~A"
                                                   sym-name
-                                                  (format-symbol-for-message system-name source)))
+                                                  (format-symbol-for-message system-name form)))
                         violations))))))))
     violations))
 
@@ -218,33 +190,27 @@ Component-def structure: (component-type component-name option*)
 - First element (component-type) can be any keyword (valid)
 - Second element (component-name) should be a string
 - Components can have :depends-on and nested :components"
-  (let ((violations '())
-        (source (parser:form-source form)))
+  (let ((violations '()))
     (dolist (component-def components)
       (when (consp component-def)
-        ;; Check component name (second element) - should be string
         (when (>= (length component-def) 2)
           (let ((component-name (second component-def)))
-            (when (looks-like-symbol-p component-name source)
+            (when (value-is-symbol-p component-name form)
               (let ((sym-name (extract-symbol-name component-name)))
                 (push (create-violation component-name form file severity
                                         (format nil "Component name should be string \"~A\", instead of symbol ~A"
                                                 sym-name
-                                                (format-symbol-for-message component-name source)))
+                                                (format-symbol-for-message component-name form)))
                       violations)))))
 
-        ;; Check component options (starting at position 2)
-        ;; Options: :depends-on, :components, etc.
         (loop for (key value) on (cddr component-def) by #'cddr
               when (stringp key)
                 do (let ((key-name (base:symbol-name-from-string key)))
                      (cond
-                       ;; Nested :components (in :module components)
                        ((string-equal key-name "COMPONENTS")
                         (when (consp value)
                           (setf violations (nconc violations
                                                   (check-components-list value form file severity)))))
-                       ;; Component :depends-on
                        ((string-equal key-name "DEPENDS-ON")
                         (when (consp value)
                           (dolist (dep value)
@@ -257,27 +223,22 @@ Component-def structure: (component-type component-name option*)
   "Check a defsystem form for symbol usage instead of strings.
 Parses the semantic structure: system name, :depends-on dependencies, :components definitions."
   (let ((violations '())
-        (expr (parser:form-expr form))
-        (source (parser:form-source form)))
+        (expr (parser:form-expr form)))
 
-    ;; Check system name (second element of defsystem form)
     (when (>= (length expr) 2)
       (let ((system-name (second expr)))
-        (when (looks-like-symbol-p system-name source)
+        (when (value-is-symbol-p system-name form)
           (let ((sym-name (extract-symbol-name system-name)))
             (push (create-violation system-name form file severity
                                     (format nil "System name should be string \"~A\", instead of symbol ~A"
                                             sym-name
-                                            (format-symbol-for-message system-name source)))
+                                            (format-symbol-for-message system-name form)))
                   violations)))))
 
-    ;; Parse options (everything after system name)
-    ;; Structure: (defsystem system-name :option1 value1 :option2 value2 ...)
     (loop for (key value) on (cddr expr) by #'cddr
           when (stringp key)
             do (let ((key-name (base:symbol-name-from-string key)))
                  (cond
-                   ;; Check :depends-on - dependencies can be simple names or complex forms
                    ((string-equal key-name "DEPENDS-ON")
                     (when (consp value)
                       (dolist (dep value)
@@ -285,13 +246,11 @@ Parses the semantic structure: system name, :depends-on dependencies, :component
                           (when dep-violations
                             (setf violations (nconc violations dep-violations)))))))
 
-                   ;; Check :components - validate component definitions
                    ((string-equal key-name "COMPONENTS")
                     (when (consp value)
                       (setf violations (nconc violations
                                               (check-components-list value form file severity)))))
 
-                   ;; Check :in-order-to - system names in dependencies
                    ((string-equal key-name "IN-ORDER-TO")
                     (when (consp value)
                       (setf violations (nconc violations

--- a/tests/fixtures/violations/asdf-component-strings.expected
+++ b/tests/fixtures/violations/asdf-component-strings.expected
@@ -1,13 +1,13 @@
 # Expected violations for asdf-component-strings.asd
 # Format: line:column rule-name severity
 
-4:12 asdf-component-strings warning
-13:16 asdf-component-strings warning
-14:16 asdf-component-strings warning
-23:23 asdf-component-strings warning
-24:23 asdf-component-strings warning
-32:12 asdf-component-strings warning
-33:16 asdf-component-strings warning
-35:23 asdf-component-strings warning
+4:11 asdf-component-strings warning
+13:15 asdf-component-strings warning
+14:15 asdf-component-strings warning
+23:22 asdf-component-strings warning
+24:22 asdf-component-strings warning
+32:11 asdf-component-strings warning
+33:15 asdf-component-strings warning
+35:22 asdf-component-strings warning
 40:15 asdf-component-strings warning
 40:27 asdf-component-strings warning

--- a/tests/rules/asdf.lisp
+++ b/tests/rules/asdf.lisp
@@ -80,4 +80,38 @@
         (let* ((text "(defsystem \"my-system\" :depends-on (\"alexandria\" #:cl-ppcre))")
                (forms (parser:parse-forms text file))
                (violations (rules:check-form rule (first forms) file)))
-          (ok (= (length violations) 1)))))))
+          (ok (= (length violations) 1))))))
+
+  (testing "Quoted symbols in :perform are not flagged"
+    (let ((rule (make-instance 'rules:asdf-component-strings-rule))
+          (file (uiop:parse-native-namestring "test.asd")))
+
+      (testing "symbol-call with #: in :perform does not cause false positives"
+        (let* ((text "(defsystem \"my-test\"
+  :depends-on (\"my-lib\")
+  :components ((:file \"test-main\"))
+  :perform (test-op (o s)
+              (symbol-call '#:my-lib/test '#:run-tests)))")
+               (forms (parser:parse-forms text file))
+               (violations (rules:check-form rule (first forms) file)))
+          (ok (null violations))))
+
+      (testing "dependency with same prefix as symbol-call arg is not flagged"
+        (let* ((text "(defsystem \"my-lib/test\"
+  :depends-on (\"my-lib\" \"fiasco\")
+  :perform (test-op (o s)
+              (symbol-call '#:fiasco '#:run-package-tests
+                           :package '#:my-lib/test)))")
+               (forms (parser:parse-forms text file))
+               (violations (rules:check-form rule (first forms) file)))
+          (ok (null violations))))
+
+      (testing ":perform does not mask real violations in :depends-on"
+        (let* ((text "(defsystem \"my-test\"
+  :depends-on (#:my-lib)
+  :perform (test-op (o s)
+              (symbol-call '#:my-lib/test '#:run-tests)))")
+               (forms (parser:parse-forms text file))
+               (violations (rules:check-form rule (first forms) file)))
+          (ok (= (length violations) 1))
+          (ok (search "my-lib" (violation:violation-message (first violations)))))))))


### PR DESCRIPTION
## Summary

- Replace source text search (`looks-like-symbol-p`, `find-symbol-in-source`) with position-map lookups (`value-is-symbol-p`, `source-char-at`) that check the character at each value's exact source position
- Eliminates false positives from quoted symbols in `:perform` bodies (e.g. `symbol-call '#:fiasco`) being matched when checking `:depends-on` entries
- Eliminates false positives from substring matches (e.g. `#:lark/util` matching `#:lark/util/test`)

Depends on #19 (tokenizer escape fix).

## Test plan

- [x] New regression tests: `:perform` with `symbol-call` does not cause false positives
- [x] New regression test: real violations in `:depends-on` are still detected alongside `:perform`
- [x] All existing asdf-component-strings tests pass
- [x] Fixture expected output updated for more accurate column positions (symbol start vs. colon)
- [x] `lark.asd` (the file that triggered the original report) now produces zero violations
- [x] Pre-commit lint hook passes