### PR TITLE
Demote formatting rules to info and default --fail-on to warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ mallet --enable line-length:max=80 --enable cyclomatic-complexity:max=10 src/
 # Disable specific rules (override config/preset)
 mallet --disable unused-variables tests/
 
-# Fail on warnings and above (useful for CI)
+# Fail on warnings and above (the default)
 mallet --fail-on warning src/
 
 # Fail on any violation (equivalent to --strict)
@@ -71,28 +71,14 @@ mallet --fail-on info src/
 ```
 
 **Severity levels** (for `--fail-on`):
-- `error` - Objectively wrong code (exit 1 by default)
-- `warning` - Likely bugs or dangerous patterns
+- `error` - Objectively wrong code
+- `warning` - Likely bugs or dangerous patterns (exit 1 by default)
 - `info` - Style preferences, metrics, and formatting suggestions
 
 **Exit codes:**
 - `0` - No violations at or above the `--fail-on` threshold
 - `1` - One or more violations at or above the threshold
 - `3` - CLI usage error (unknown flag, missing argument, invalid file)
-
-> **Migration note:** Previous versions used exit code 2 for `:error`-level violations
-> and exit code 1 for `:warning`-level violations. Both now exit 1. If your CI pipeline
-> distinguished between exit 2 and exit 1, replace that logic with `--fail-on`:
->
-> ```bash
-> # Old: exit 2 for errors only
-> # New equivalent:
-> mallet --fail-on error src/   # exit 1 if any :error violation found
->
-> # Old: exit 1 for warnings, exit 2 for errors
-> # New equivalent (treat warnings as failures too):
-> mallet --fail-on warning src/
-> ```
 
 ### Auto-Fix
 

--- a/RULES.md
+++ b/RULES.md
@@ -2,61 +2,88 @@
 
 Rules are organized by category. Each rule shows its severity and default preset status.
 
-**Severity levels**: `error` (exit code 2), `warning` (exit code 1), `info` (exit code 0)
+**Severity levels**: `error`, `warning`, `info`
 
 **Suppressing violations**: Any rule can be suppressed using `#+mallet (declaim (mallet:suppress-next :rule-name))`. See the README for details.
 
-## Table of Contents
+## Rule List
 
-- [Correctness](#correctness) — Objectively wrong code
-  - [`:wrong-otherwise`](#wrong-otherwise) - `ecase`/`etypecase` with `otherwise`/`t` clause
-  - [`:mixed-optional-and-key`](#mixed-optional-and-key) - Mixing `&optional` and `&key` parameters
-  - [`:asdf-if-feature-keyword`](#asdf-if-feature-keyword) - Feature expressions must use keywords in defsystem
-- [Suspicious](#suspicious) — Likely wrong or dangerous patterns
-  - [`:eval-usage`](#eval-usage) - Runtime use of `cl:eval`
-  - [`:runtime-intern`](#runtime-intern) - Runtime use of symbol-interning functions
-  - [`:runtime-unintern`](#runtime-unintern) - Runtime use of `cl:unintern`
-- [Practice](#practice) — Commonly accepted best practices
-  - [`:no-package-use`](#no-package-use) - Use of `:use` in `defpackage`
-  - [`:ignore-errors-usage`](#ignore-errors-usage) - Use of `cl:ignore-errors`
-  - [`:allow-other-keys`](#allow-other-keys) - Use of `&allow-other-keys` in lambda lists
-  - [`:double-colon-access`](#double-colon-access) - Accessing internal symbols via `::`
-  - [`:error-with-string-only`](#error-with-string-only) - Calling `error` with only a format string
-  - [`:missing-exported-docstring`](#missing-exported-docstring) - Exported definitions missing docstrings
-  - [`:asdf-operate-in-perform`](#asdf-operate-in-perform) - Calling `asdf:operate` and friends inside `:perform`
-  - [`:asdf-reader-conditional`](#asdf-reader-conditional) - Using `#+`/`#-` reader conditionals in defsystem
-- [Cleanliness](#cleanliness) — Dead code and unused definitions
-  - [`:unused-variables`](#unused-variables) - Variables that are never used
-  - [`:unused-local-functions`](#unused-local-functions) - Local functions that are never called
-  - [`:unused-local-nicknames`](#unused-local-nicknames) - Local nicknames that are never used
-  - [`:unused-imported-symbols`](#unused-imported-symbols) - Imported symbols that are never used
-  - [`:unused-loop-variables`](#unused-loop-variables) - Loop variables that are never used
-- [Style](#style) — Idiomatic patterns and naming
-  - [`:if-without-else`](#if-without-else) - Use `when`/`unless` instead of `if` without else
-  - [`:bare-progn`](#bare-progn) - Use `cond`/`when`/`unless` instead of `if`/`and`/`or` with bare `progn`
-  - [`:missing-otherwise`](#missing-otherwise) - `case`/`typecase` without `otherwise` clause
-  - [`:interned-package-symbol`](#interned-package-symbol) - Use uninterned symbols in package definitions
-  - [`:needless-let*`](#needless-let) - Use `let` when bindings are independent
-  - [`:special-variable-naming`](#special-variable-naming) - Special variables should be named `*foo*`
-  - [`:constant-naming`](#constant-naming) - Constants should be named `+foo+`
-  - [`:asdf-component-strings`](#asdf-component-strings) - ASDF components should use strings
-  - [`:asdf-redundant-package-prefix`](#asdf-redundant-package-prefix) - Redundant package prefixes in `.asd` files
-  - [`:asdf-secondary-system-name`](#asdf-secondary-system-name) - Secondary system names must follow `primary/suffix` convention
-  - [`:bare-float-literal`](#bare-float-literal) - Float literals should have explicit type markers
-  - [`:missing-docstring`](#missing-docstring) - Top-level definitions missing docstrings
-- [Format](#format) — Whitespace and file formatting
-  - [`:trailing-whitespace`](#trailing-whitespace) - Lines should not have trailing whitespace
-  - [`:no-tabs`](#no-tabs) - Use spaces instead of tab characters
-  - [`:final-newline`](#final-newline) - Files must end with a newline
-  - [`:closing-paren-on-own-line`](#closing-paren-on-own-line) - Closing parens should follow the last expression
-  - [`:line-length`](#line-length) - Lines should not exceed maximum length
-  - [`:consecutive-blank-lines`](#consecutive-blank-lines) - Limit consecutive blank lines
-- [Metrics](#metrics) — Code quality measurements
-  - [`:function-length`](#function-length) - Function exceeds maximum line count
-  - [`:cyclomatic-complexity`](#cyclomatic-complexity) - Function has high cyclomatic complexity
-  - [`:comment-ratio`](#comment-ratio) - Function has too many comments relative to code
-- [CLEANLINESS](#cleanliness)
-  - [`:stale-suppression`](#stale-suppression) - Suppression directive has no effect
+### [Correctness](#correctness) — Objectively wrong code
+
+| Rule | Description | Severity | Default | Options |
+|------|-------------|----------|---------|---------|
+| [`:wrong-otherwise`](#wrong-otherwise) | `ecase`/`etypecase` with `otherwise`/`t` clause | error | on | |
+| [`:mixed-optional-and-key`](#mixed-optional-and-key) | Mixing `&optional` and `&key` parameters | error | on | |
+| [`:asdf-if-feature-keyword`](#asdf-if-feature-keyword) | Feature expressions must use keywords in defsystem | warning | on | |
+
+### [Suspicious](#suspicious) — Likely wrong or dangerous patterns
+
+| Rule | Description | Severity | Default | Options |
+|------|-------------|----------|---------|---------|
+| [`:eval-usage`](#eval-usage) | Runtime use of `cl:eval` | warning | on | |
+| [`:runtime-intern`](#runtime-intern) | Runtime use of symbol-interning functions | warning | off | |
+| [`:runtime-unintern`](#runtime-unintern) | Runtime use of `cl:unintern` | warning | off | |
+
+### [Practice](#practice) — Commonly accepted best practices
+
+| Rule | Description | Severity | Default | Options |
+|------|-------------|----------|---------|---------|
+| [`:no-package-use`](#no-package-use) | Use of `:use` in `defpackage` | warning | on | |
+| [`:ignore-errors-usage`](#ignore-errors-usage) | Use of `cl:ignore-errors` | warning | on | |
+| [`:allow-other-keys`](#allow-other-keys) | Use of `&allow-other-keys` in lambda lists | warning | on | |
+| [`:double-colon-access`](#double-colon-access) | Accessing internal symbols via `::` | warning | on | |
+| [`:error-with-string-only`](#error-with-string-only) | Calling `error` with only a format string | warning | off | |
+| [`:missing-exported-docstring`](#missing-exported-docstring) | Exported definitions missing docstrings | warning | on | |
+| [`:asdf-operate-in-perform`](#asdf-operate-in-perform) | Calling `asdf:operate` inside `:perform` | warning | on | |
+| [`:asdf-reader-conditional`](#asdf-reader-conditional) | `#+`/`#-` reader conditionals in defsystem | warning | off | |
+
+### [Cleanliness](#cleanliness) — Dead code and unused definitions
+
+| Rule | Description | Severity | Default | Fix | Options |
+|------|-------------|----------|---------|-----|---------|
+| [`:unused-variables`](#unused-variables) | Variables that are never used | warning | on | | |
+| [`:unused-local-functions`](#unused-local-functions) | Local functions that are never called | warning | on | | |
+| [`:unused-local-nicknames`](#unused-local-nicknames) | Local nicknames that are never used | warning | on | yes | |
+| [`:unused-imported-symbols`](#unused-imported-symbols) | Imported symbols that are never used | warning | on | yes | |
+| [`:unused-loop-variables`](#unused-loop-variables) | Loop variables that are never used | info | off | | |
+| [`:stale-suppression`](#stale-suppression) | Suppression directive has no effect | warning | on | | |
+
+### [Style](#style) — Idiomatic patterns and naming
+
+| Rule | Description | Severity | Default | Options |
+|------|-------------|----------|---------|---------|
+| [`:if-without-else`](#if-without-else) | Use `when`/`unless` instead of `if` without else | warning | on | |
+| [`:bare-progn`](#bare-progn) | Use `cond`/`when`/`unless` instead of bare `progn` | info | off | |
+| [`:missing-otherwise`](#missing-otherwise) | `case`/`typecase` without `otherwise` clause | info | off | |
+| [`:interned-package-symbol`](#interned-package-symbol) | Use uninterned symbols in package definitions | info | off | |
+| [`:needless-let*`](#needless-let) | Use `let` when bindings are independent | warning | on | |
+| [`:special-variable-naming`](#special-variable-naming) | Special variables should be named `*foo*` | info | off | |
+| [`:constant-naming`](#constant-naming) | Constants should be named `+foo+` | info | off | |
+| [`:asdf-component-strings`](#asdf-component-strings) | ASDF components should use strings | warning | on | |
+| [`:asdf-redundant-package-prefix`](#asdf-redundant-package-prefix) | Redundant package prefixes in `.asd` files | info | on | |
+| [`:asdf-secondary-system-name`](#asdf-secondary-system-name) | Secondary systems must use `primary/suffix` name | warning | on | |
+| [`:bare-float-literal`](#bare-float-literal) | Float literals should have explicit type markers | info | off | |
+| [`:missing-docstring`](#missing-docstring) | Top-level definitions missing docstrings | info | off | |
+| [`:redundant-progn`](#redundant-progn) | `progn` with a single body form is redundant | info | on | |
+
+### [Format](#format) — Whitespace and file formatting
+
+| Rule | Description | Severity | Default | Fix | Options |
+|------|-------------|----------|---------|-----|---------|
+| [`:trailing-whitespace`](#trailing-whitespace) | Lines with trailing whitespace | info | on | yes | |
+| [`:no-tabs`](#no-tabs) | Tab characters in source | info | on | | |
+| [`:final-newline`](#final-newline) | Files must end with a newline | info | on | yes | |
+| [`:closing-paren-on-own-line`](#closing-paren-on-own-line) | Closing parens on their own line | info | on | | |
+| [`:line-length`](#line-length) | Lines exceeding maximum length | info | off | | `:max` (100) |
+| [`:consecutive-blank-lines`](#consecutive-blank-lines) | Excessive consecutive blank lines | info | off | yes | `:max` (2) |
+
+### [Metrics](#metrics) — Code quality measurements
+
+| Rule | Description | Severity | Default | Options |
+|------|-------------|----------|---------|---------|
+| [`:function-length`](#function-length) | Function exceeds maximum line count | info | off | `:max` (50) |
+| [`:cyclomatic-complexity`](#cyclomatic-complexity) | Function has high cyclomatic complexity | info | off | `:max` (20), `:variant` (standard) |
+| [`:comment-ratio`](#comment-ratio) | Function has too many comments | info | off | `:max` (0.3), `:min-lines` (5), `:include-docstrings` (nil) |
 
 ## Correctness
 
@@ -440,6 +467,30 @@ Loop variables should be used within the loop body.
 
 **Severity**: info | **Default**: disabled
 
+### `:stale-suppression`
+
+A suppression directive (inline comment or `#+mallet` form) has no effect because no matching violation was found at the suppressed location.
+
+This rule fires when:
+- A `; mallet:suppress rule-name` comment is present but the named rule produces no violation on that form.
+- A `; mallet:disable` / `; mallet:enable` region contains no violations for the listed rules.
+
+Enable this rule to catch outdated suppression comments left behind after code changes.
+
+```lisp
+;; Bad: no violation here, suppression is stale
+(let ((x (foo))     ; mallet:suppress needless-let*
+      (y (bar)))
+  (list x y))
+
+;; Good: violation exists, suppression is meaningful
+(let* ((x (foo))    ; mallet:suppress needless-let*
+       (y (bar)))
+  (list x y))
+```
+
+**Severity**: warning | **Default**: enabled
+
 ## Style
 
 Rules for idiomatic patterns and naming conventions.
@@ -686,6 +737,24 @@ Top-level definitions should have docstrings. Applies to `defun`, `defmacro`, `d
 
 **Severity**: info | **Default**: disabled
 
+### `:redundant-progn`
+
+`progn` with a single body form is redundant — the `progn` wrapper can be removed.
+
+```lisp
+;; Bad: progn with one form
+(progn
+  (do-something))
+
+;; Good: no wrapper needed
+(do-something)
+```
+
+**Exclusions**:
+- `progn` wrapping a single `,@splice` (unquote-splicing) is allowed, since the splice may expand to multiple forms
+
+**Severity**: info | **Default**: enabled
+
 ## Format
 
 Rules for whitespace and file formatting. These follow strong community consensus (Emacs/SLIME standards).
@@ -696,13 +765,13 @@ Lines should not have trailing whitespace.
 
 **Auto-fixable**: `--fix` removes trailing whitespace.
 
-**Severity**: warning | **Default**: enabled
+**Severity**: info | **Default**: enabled
 
 ### `:no-tabs`
 
 Use spaces instead of tab characters.
 
-**Severity**: warning | **Default**: enabled
+**Severity**: info | **Default**: enabled
 
 ### `:final-newline`
 
@@ -710,7 +779,7 @@ Files must end with a newline.
 
 **Auto-fixable**: `--fix` appends a newline.
 
-**Severity**: warning | **Default**: enabled
+**Severity**: info | **Default**: enabled
 
 ### `:closing-paren-on-own-line`
 
@@ -737,7 +806,7 @@ Closing parentheses should follow the last expression on the same line, not appe
     ))
 ```
 
-**Severity**: warning | **Default**: enabled
+**Severity**: info | **Default**: enabled
 
 ### `:line-length`
 
@@ -822,36 +891,6 @@ Nested `flet`/`labels` functions are counted separately.
 
 Notes:
 - Functions with fewer qualifying lines (comment + code) than `:min-lines` are skipped. Docstring lines are not counted toward the threshold unless `:include-docstrings t` is set.
-- Nested `flet`/`labels` functions are counted separately
 
 **Severity**: info | **Default**: disabled
 
-## CLEANLINESS
-
-Rules that detect housekeeping issues in suppression directives. These are opt-in and pair with the inline comment suppression feature.
-
-### `:stale-suppression`
-
-A suppression directive (inline comment or `#+mallet` form) has no effect because no matching violation was found at the suppressed location.
-
-This rule fires when:
-- A `; mallet:suppress rule-name` comment is present but the named rule produces no violation on that form.
-- A `; mallet:disable` / `; mallet:enable` region contains no violations for the listed rules.
-
-Enable this rule to catch outdated suppression comments left behind after code changes.
-
-```lisp
-;; Bad: no violation here, suppression is stale
-(let ((x (foo))     ; mallet:suppress needless-let*
-      (y (bar)))
-  (list x y))
-
-;; Good: violation exists, suppression is meaningful
-(let* ((x (foo))    ; mallet:suppress needless-let*
-       (y (bar)))
-  (list x y))
-```
-
-**Category**: `:cleanliness`
-**Severity**: `:warning`
-**Default**: enabled (`:warning` severity; included in `:default` and `:all` presets)

--- a/src/main.lisp
+++ b/src/main.lisp
@@ -206,7 +206,7 @@ Signals specific error conditions for invalid input."
         (debug nil)
         (no-color nil)
         (fix-mode nil)
-        (fail-on :error)
+        (fail-on :warning)
         (enable-rules '())
         (disable-rules '())
         (files '()))
@@ -283,7 +283,7 @@ Options:
   --enable <rule:opts> Enable rule with options (e.g., --enable line-length:max=120)
   --disable <rule>    Disable specific rule (e.g., --disable trailing-whitespace)
 
-  --fail-on <level>   Exit 1 if any violation meets or exceeds level (error, warning, info; default: error)
+  --fail-on <level>   Exit 1 if any violation meets or exceeds level (error, warning, info; default: warning)
   --strict            Alias for --fail-on info (exit 1 for any violation)
 
   --fix               Auto-fix violations and write files
@@ -304,8 +304,8 @@ Presets:
   none                No rules enabled (explicitly enable specific rules)
 
 Severity Levels (for --fail-on):
-  error               Objectively wrong code (exit 1 by default)
-  warning             Likely bugs or dangerous patterns
+  error               Objectively wrong code
+  warning             Likely bugs or dangerous patterns (exit 1 by default)
   info                Style preferences, metrics, and formatting suggestions
 
 Examples:
@@ -318,7 +318,7 @@ Examples:
   mallet --fix src/                   # Auto-fix violations
   mallet --fix-dry-run src/           # Preview fixes without changing files
 
-  # Fail on warnings and above (CI-friendly)
+  # Fail on warnings and above (the default)
   mallet --fail-on warning src/
 
   # Fail on any violation (equivalent to --strict)

--- a/src/rules/text.lisp
+++ b/src/rules/text.lisp
@@ -86,7 +86,7 @@ Returns the line content as a string, or NIL if line doesn't exist."
   (:default-initargs
    :name :trailing-whitespace
    :description "Lines should not have trailing whitespace"
-   :severity :warning
+   :severity :info
    :category :format
    :type :text)
   (:documentation "Rule to check for trailing whitespace on lines."))
@@ -147,7 +147,7 @@ Returns the line content as a string, or NIL if line doesn't exist."
   (:default-initargs
    :name :no-tabs
    :description "Use spaces instead of tab characters"
-   :severity :warning
+   :severity :info
    :category :format
    :type :text)
   (:documentation "Rule to check for tab characters."))
@@ -185,7 +185,7 @@ Returns the line content as a string, or NIL if line doesn't exist."
   (:default-initargs
    :name :final-newline
    :description "Files must end with a newline"
-   :severity :warning
+   :severity :info
    :category :format
    :type :text)
   (:documentation "Rule to check that files end with a newline."))
@@ -318,7 +318,7 @@ Returns the line content as a string, or NIL if line doesn't exist."
   (:default-initargs
    :name :closing-paren-on-own-line
    :description "Closing parentheses should not appear alone on a line; place them at the end of the last expression"
-   :severity :warning
+   :severity :info
    :category :format
    :type :text)
   (:documentation "Rule to detect lines consisting only of closing parentheses.

--- a/tests/cli-integration-test.sh
+++ b/tests/cli-integration-test.sh
@@ -108,10 +108,10 @@ for file in "$VIOLATIONS_DIR"/*.lisp "$VIOLATIONS_DIR"/*.asd; do
         fi
 
         # Determine expected exit code based on highest severity
-        # Default --fail-on is error: exit 1 only for errors, not warnings/info
+        # Default --fail-on is warning: exit 1 for errors or warnings, not info
         EXPECTED_EXIT_CODE=0
         if [ -f "$expected_file" ]; then
-            if grep -q ' error$' "$expected_file" 2>/dev/null; then
+            if grep -q ' error$' "$expected_file" 2>/dev/null || grep -q ' warning$' "$expected_file" 2>/dev/null; then
                 EXPECTED_EXIT_CODE=1
             fi
         fi

--- a/tests/config-test.lisp
+++ b/tests/config-test.lisp
@@ -757,7 +757,7 @@
 (deftest set-severity-applies-to-for-paths
   (testing ":set-severity propagates into :for-paths rules"
     (let* ((sexp '(:mallet-config
-                   (:enable :trailing-whitespace)    ; :format, default :warning
+                   (:enable :trailing-whitespace)    ; :format, default :info
                    (:set-severity :format :error)
                    (:for-paths ("tests/**/*.lisp")
                     (:enable :unused-variables))))   ; :cleanliness, unaffected category

--- a/tests/fixtures/violations/closing-paren-on-own-line.expected
+++ b/tests/fixtures/violations/closing-paren-on-own-line.expected
@@ -1,6 +1,6 @@
 # Expected violations for closing-paren-on-own-line.lisp
 # Format: line:column rule-name severity
 
-7:4 closing-paren-on-own-line warning
-8:2 closing-paren-on-own-line warning
-13:8 closing-paren-on-own-line warning
+7:4 closing-paren-on-own-line info
+8:2 closing-paren-on-own-line info
+13:8 closing-paren-on-own-line info

--- a/tests/fixtures/violations/text-formatting.expected
+++ b/tests/fixtures/violations/text-formatting.expected
@@ -1,4 +1,4 @@
 # Format: line:column rule-name severity
-12:0 no-tabs warning
+12:0 no-tabs info
 18:0 consecutive-blank-lines info
-22:0 final-newline warning
+22:0 final-newline info

--- a/tests/rules/closing-paren-on-own-line-test.lisp
+++ b/tests/rules/closing-paren-on-own-line-test.lisp
@@ -139,11 +139,11 @@
     ))")))
       (ok (= 1 (length violations)))))
 
-  (testing "Severity is :warning"
+  (testing "Severity is :info"
     (let ((violations (check-closing-paren
                        (format nil "(defun foo ()~%  )"))))
       (ok (= 1 (length violations)))
-      (ok (eq :warning (violation:violation-severity (first violations))))))
+      (ok (eq :info (violation:violation-severity (first violations))))))
 
   (testing "Violation message mentions closing paren"
     (let* ((violations (check-closing-paren


### PR DESCRIPTION
## Summary

- Demote 4 formatting rules (trailing-whitespace, no-tabs, final-newline, closing-paren-on-own-line) from `:warning` to `:info` severity — they are cosmetic, not "likely problematic"
- Change `--fail-on` default from `:error` to `:warning` — warnings now fail CI by default, aligning with the design intent in `docs/rule-classification.md`
- Restructure RULES.md: replace bullet-list ToC with category tables showing severity, default status, fix support, and options at a glance
- Fix documentation issues: add missing `redundant-progn` rule, consolidate duplicate Cleanliness section, fix outdated exit-code references, remove obsolete migration note

## Rationale

With only 2 error-level rules and `--fail-on :error` as the default, most violations were invisible to CI. Formatting rules inflated the warning tier, making it span from "likely bugs" to "trailing whitespace." This change sharpens the severity model:

- **error** = almost certainly broken (2 rules)
- **warning** = likely problematic, CI blocker by default (18 rules)
- **info** = style, formatting, metrics (11+ rules)