### PR TITLE
Fix #50: error-without-custom-condition false positive on non-CL packages

### DIFF
--- a/src/rules/forms/error-usage.lisp
+++ b/src/rules/forms/error-usage.lisp
@@ -67,9 +67,16 @@ a valid fix because callers cannot distinguish them from any other error."))
   "Return T if HEAD (parser string symbol or CL symbol) is a call to CL:ERROR."
   (typecase head
     (string
-     ;; Parser represents symbols as strings with package prefix.
-     ;; error appears as \"CURRENT:error\" (unqualified) or \"cl:error\" (qualified)
-     (base:symbol-matches-p head "ERROR"))
+     ;; Parser represents symbols as strings with package prefix:
+     ;; "CURRENT:error" (unqualified), "cl:error" (qualified), "common-lisp:error".
+     ;; A non-CL package prefix (e.g. "log:error") must NOT match — issue #50.
+     (let ((colon-pos (position #\: head :from-end t)))
+       (when colon-pos
+         (let ((pkg  (subseq head 0 colon-pos))
+               (name (subseq head (1+ colon-pos))))
+           (and (string-equal name "ERROR")
+                (or (member pkg '("cl" "common-lisp") :test #'string-equal)
+                    (string-equal pkg "CURRENT")))))))
     (symbol
      ;; Directly interned CL symbol (rare but possible from reader macros)
      (and (string-equal (symbol-name head) "ERROR")

--- a/tests/rules/error-without-custom-condition-test.lisp
+++ b/tests/rules/error-without-custom-condition-test.lisp
@@ -52,7 +52,19 @@
     (ok (null (check-error-custom "(signal \"something\")"))))
 
   (testing "cerror with string is not flagged (different function)"
-    (ok (null (check-error-custom "(cerror \"continue\" \"something\")")))))
+    (ok (null (check-error-custom "(cerror \"continue\" \"something\")"))))
+
+  (testing "(log:error \"msg\") with non-CL package is not flagged (issue #50)"
+    (ok (null (check-error-custom "(log:error \"something went wrong\")"))))
+
+  (testing "(my-pkg:error \"msg\") with arbitrary package is not flagged"
+    (ok (null (check-error-custom "(my-pkg:error \"bad\")"))))
+
+  (testing "(log:error \"fmt ~A\" v) format-string + arg with non-CL package is not flagged"
+    (ok (null (check-error-custom "(log:error \"value ~A\" v)"))))
+
+  (testing "(log:error 'simple-error ...) non-CL head with quoted CL condition is not flagged"
+    (ok (null (check-error-custom "(log:error 'simple-error \"detail\")")))))
 
 ;;; Invalid cases (violations expected) — string literal first arg
 
@@ -105,7 +117,12 @@
 
   (testing "error with empty string is flagged"
     (let ((violations (check-error-custom "(error \"\")")))
-      (ok (= (length violations) 1)))))
+      (ok (= (length violations) 1))))
+
+  (testing "(CL:error \"msg\") uppercase qualifier is flagged (case-insensitivity guard)"
+    (let ((violations (check-error-custom "(CL:error \"bad\")")))
+      (ok (= (length violations) 1))
+      (ok (eq (violation:violation-rule (first violations)) :error-without-custom-condition)))))
 
 ;;; Invalid cases (violations expected) — quoted CL-package condition symbols
 


### PR DESCRIPTION
## What
`error-without-custom-condition` no longer fires on operators whose local symbol-name is `ERROR` but whose package is not `cl` / `common-lisp`. The string branch of `error-call-head-p` (`src/rules/forms/error-usage.lisp`) now splits the parser's `pkg:name` representation on the last colon and requires the prefix to be `cl`, `common-lisp`, or `CURRENT` (the parser's marker for unqualified symbols in the current package), mirroring the pattern already used by `quoted-cl-condition-p` in the same file.

## Why
Reported in #50: `(log:error "msg")` (a log4cl logging macro that signals nothing) was treated as `cl:error` because the previous check used `base:symbol-matches-p`, which compares only the local name after the last colon. Any operator whose local name is `ERROR` — `log:error`, `my-pkg:error`, etc. — was indistinguishable from `cl:error`. The symbol branch (used for reader-injected CL symbols) already handled the package correctly; only the string branch was missing the check.

The unrelated `(not (find #\: arg))` first-argument check is left alone — it was sometimes accidentally suppressing the bug for inputs whose format string contained a colon, but it's a separate concern.

Tests added in `tests/rules/error-without-custom-condition-test.lisp`:
- `(log:error "msg")`, `(my-pkg:error "msg")`, `(log:error "fmt ~A" v)`, `(log:error 'simple-error "detail")` — must not fire.
- `(CL:error "msg")` uppercase qualifier — must still fire (case-insensitivity guard).

Closes #50.