### PR TITLE
Suppress unused-variables warning for special-declared let bindings

### DIFF
--- a/src/rules/forms/variables.lisp
+++ b/src/rules/forms/variables.lisp
@@ -576,7 +576,12 @@ CONTEXT determines interpretation of ambiguous 2-element lists:
     (t nil)))
 
 (defun extract-ignored-vars (body)
-  "Extract variable names from (declare (ignore ...)) and (declare (ignorable ...)) forms."
+  "Extract variable names from (declare (ignore ...)), (declare (ignorable ...)),
+and (declare (special ...)) forms.
+
+SPECIAL declarations are included because they turn the binding into a dynamic
+binding — any function call in BODY may read or write the variable through
+dynamic scope, so it cannot be flagged as unused on lexical grounds alone."
   (let ((ignored '()))
     (dolist (form body)
       (when (and (consp form)
@@ -586,7 +591,8 @@ CONTEXT determines interpretation of ambiguous 2-element lists:
           (dolist (decl-spec (rest form))
             (when (and (consp decl-spec)
                        (or (base:symbol-matches-p (first decl-spec) "IGNORE")
-                           (base:symbol-matches-p (first decl-spec) "IGNORABLE")))
+                           (base:symbol-matches-p (first decl-spec) "IGNORABLE")
+                           (base:symbol-matches-p (first decl-spec) "SPECIAL")))
               ;; Only iterate if it's a proper list (not a dotted pair)
               (when (and (listp (rest decl-spec)) (a:proper-list-p (rest decl-spec)))
                 (dolist (var (rest decl-spec))

--- a/tests/rules/unused-variables-test.lisp
+++ b/tests/rules/unused-variables-test.lisp
@@ -57,6 +57,33 @@
            (forms (parser:parse-forms code #p"test.lisp"))
            (rule (make-instance 'rules:unused-variables-rule))
            (violations (rules:check-form rule (first forms) #p"test.lisp")))
+      (ok (null violations))))
+
+  (testing "Valid: let binding with declare special (dynamic binding)"
+    (let* ((code "(let ((my-var 42))
+                     (declare (special my-var))
+                     (do-something))")
+           (forms (parser:parse-forms code #p"test.lisp"))
+           (rule (make-instance 'rules:unused-variables-rule))
+           (violations (rules:check-form rule (first forms) #p"test.lisp")))
+      (ok (null violations))))
+
+  (testing "Valid: let* binding with declare special (dynamic binding)"
+    (let* ((code "(let* ((my-var 42))
+                     (declare (special my-var))
+                     (do-something))")
+           (forms (parser:parse-forms code #p"test.lisp"))
+           (rule (make-instance 'rules:unused-variables-rule))
+           (violations (rules:check-form rule (first forms) #p"test.lisp")))
+      (ok (null violations))))
+
+  (testing "Valid: declare special with multiple variables"
+    (let* ((code "(let ((a 1) (b 2))
+                     (declare (special a b))
+                     (do-something))")
+           (forms (parser:parse-forms code #p"test.lisp"))
+           (rule (make-instance 'rules:unused-variables-rule))
+           (violations (rules:check-form rule (first forms) #p"test.lisp")))
       (ok (null violations)))))
 
 (deftest unused-variables-invalid


### PR DESCRIPTION
## What
Stop reporting `unused-variables` for a `let` / `let*` binding when the body contains `(declare (special var))` for that variable.

## Why
A `(declare (special var))` inside a binding form turns the binding into a dynamic binding, so any function called within the body may read or write the variable through dynamic scope. Lexical reachability alone cannot prove it is unused, and the existing earmuff rule (`special-variable-p`) only covers the `*name*` convention. Variables made dynamic via a local `SPECIAL` declaration but without earmuffs were producing false positives.

## Limitations
Variables made special only via top-level `declaim`/`proclaim (special …)` (no earmuffs, no local `declare`) still get flagged. Tracking those requires file-wide state, which is out of scope here.