### PR TITLE
Drop :double-colon-access from :strict preset

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -41,7 +41,7 @@ The **Default** column below reflects `:default` preset membership. Rules marked
 | [`:no-package-use`](#no-package-use) | Use of `:use` in `defpackage` | warning | strict | |
 | [`:no-ignore-errors`](#no-ignore-errors) | Use of `cl:ignore-errors` | warning | on | |
 | [`:no-allow-other-keys`](#no-allow-other-keys) | Use of `&allow-other-keys` in lambda lists | warning | strict | |
-| [`:double-colon-access`](#double-colon-access) | Accessing internal symbols via `::` | warning | strict | |
+| [`:double-colon-access`](#double-colon-access) | Accessing internal symbols via `::` | warning | off | |
 | [`:error-without-custom-condition`](#error-without-custom-condition) | Calling `error` without a custom condition type | warning | strict | |
 | [`:asdf-component-strings`](#asdf-component-strings) | ASDF components should use strings | warning | on | |
 | [`:asdf-reader-conditional`](#asdf-reader-conditional) | `#+`/`#-` reader conditionals in defsystem | info | strict | |
@@ -372,7 +372,7 @@ Avoid accessing internal symbols via `::` package qualifier. Using `::` bypasses
 (my-lib:public-function arg)
 ```
 
-**Severity**: warning | **Default**: disabled (`:strict` and above)
+**Severity**: warning | **Default**: disabled
 
 ### `:error-without-custom-condition`
 

--- a/src/config.lisp
+++ b/src/config.lisp
@@ -623,7 +623,6 @@ Suitable for new projects and AI-assisted coding where stricter checking is desi
          (extra-rules
            '(;; Opinionated practice rules (removed from :default)
              :no-package-use
-             :double-colon-access
              :closing-paren-on-own-line
              :redundant-progn
              ;; Additional practice rules

--- a/tests/config-test.lisp
+++ b/tests/config-test.lisp
@@ -148,7 +148,7 @@
         (ok (member :no-ignore-errors rule-names))
         ;; Opinionated rules added beyond :default
         (ok (member :no-package-use rule-names))
-        (ok (member :double-colon-access rule-names))
+        (ok (not (member :double-colon-access rule-names)))
         (ok (member :closing-paren-on-own-line rule-names))
         (ok (member :redundant-progn rule-names))
         (ok (member :no-allow-other-keys rule-names))

--- a/tests/rules/double-colon-access-test.lisp
+++ b/tests/rules/double-colon-access-test.lisp
@@ -108,14 +108,14 @@
 ;;; Registration tests
 
 (deftest double-colon-access-registration
-  (testing ":double-colon-access is NOT in :default config (moved to :strict)"
+  (testing ":double-colon-access is NOT in :default config"
     (let* ((cfg (mallet/config:get-built-in-config :default))
            (rule-names (mapcar #'rules:rule-name (mallet/config:config-rules cfg))))
       (ok (not (member :double-colon-access rule-names)))))
-  (testing ":double-colon-access IS in :strict config"
+  (testing ":double-colon-access is NOT in :strict config (opt-in only)"
     (let* ((cfg (mallet/config:get-built-in-config :strict))
            (rule-names (mapcar #'rules:rule-name (mallet/config:config-rules cfg))))
-      (ok (member :double-colon-access rule-names))))
+      (ok (not (member :double-colon-access rule-names)))))
 
   (testing ":double-colon-access is in :all config"
     (let* ((cfg (mallet/config:get-built-in-config :all))


### PR DESCRIPTION
## What
Remove `:double-colon-access` from the `:strict` preset. The rule remains in `:all` and can still be enabled explicitly via `--enable double-colon-access`.

## Why
`::` access is sometimes needed as a deliberate workaround (testing internals, interop) and is opinionated enough that strict-preset users may not want it forced on. Keeping it opt-in matches its original classification — opinionated, with legitimate use cases.